### PR TITLE
feat: Add Open Data generation workflow

### DIFF
--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -26,7 +26,7 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
 
       - name: Start Elasticsearch
-        run: docker-compose up -d elasticsearch
+        run: docker compose up -d elasticsearch
 
       - name: Wait for Elasticsearch
         run: |
@@ -34,11 +34,11 @@ jobs:
 
       - name: Install GCS Plugin & Keystore
         run: |
-          docker-compose exec -T elasticsearch bin/elasticsearch-plugin install -b repository-gcs
-          docker-compose exec -T elasticsearch bin/elasticsearch-keystore add-file gcs.client.default.credentials_file data/gcs.json
+          docker compose exec -T elasticsearch bin/elasticsearch-plugin install -b repository-gcs
+          docker compose exec -T elasticsearch bin/elasticsearch-keystore add-file gcs.client.default.credentials_file data/gcs.json
 
       - name: Restart Elasticsearch
-        run: docker-compose restart elasticsearch
+        run: docker compose restart elasticsearch
 
       - name: Wait for Elasticsearch again
         run: |

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -6,6 +6,19 @@ on:
 jobs:
   generate-opendata:
     runs-on: ubuntu-latest
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
+        ports:
+          - 62223:9200
+        env:
+          discovery.type: single-node
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cat/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -20,27 +33,37 @@ jobs:
           mkdir -p esdata
           echo "$GCS_CREDENTIALS" > esdata/gcs.json
           chmod 644 esdata/gcs.json
-          # Ensure esdata is writable by container user (uid 1000) just in case
-          sudo chown -R 1000:1000 esdata
         env:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
 
-      - name: Start Elasticsearch
-        run: docker compose up -d elasticsearch
-
-      - name: Wait for Elasticsearch
-        run: |
-          timeout 60 bash -c 'until curl -s http://localhost:62223/_cat/health > /dev/null; do sleep 5; done'
-
       - name: Install GCS Plugin & Keystore
         run: |
-          docker compose exec -T elasticsearch bin/elasticsearch-plugin install -b repository-gcs
-          docker compose exec -T elasticsearch bin/elasticsearch-keystore add-file gcs.client.default.credentials_file data/gcs.json
+          # Find the container ID
+          CONTAINER_ID=$(docker ps --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2" --format "{{.ID}}")
+          echo "Elasticsearch container ID: $CONTAINER_ID"
 
-      - name: Restart Elasticsearch
-        run: docker compose restart elasticsearch
+          if [ -z "$CONTAINER_ID" ]; then
+            echo "Error: Elasticsearch container not found"
+            exit 1
+          fi
 
-      - name: Wait for Elasticsearch again
+          # Install plugin
+          docker exec $CONTAINER_ID bin/elasticsearch-plugin install -b repository-gcs
+
+          # Add credentials to keystore
+          # Copy credentials file into container
+          docker cp esdata/gcs.json $CONTAINER_ID:/usr/share/elasticsearch/config/gcs.json
+
+          # Add to keystore
+          docker exec $CONTAINER_ID bin/elasticsearch-keystore add-file gcs.client.default.credentials_file /usr/share/elasticsearch/config/gcs.json
+
+          # Clean up credentials file inside container
+          docker exec $CONTAINER_ID rm /usr/share/elasticsearch/config/gcs.json
+
+          # Restart container to load plugin
+          docker restart $CONTAINER_ID
+
+      - name: Wait for Elasticsearch
         run: |
           timeout 60 bash -c 'until curl -s http://localhost:62223/_cat/health > /dev/null; do sleep 5; done'
 

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -1,0 +1,93 @@
+name: Generate Open Data
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-opendata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Prepare directory and secrets
+        run: |
+          mkdir -p esdata
+          echo "$GCS_CREDENTIALS" > esdata/gcs.json
+          chmod 644 esdata/gcs.json
+          # Ensure esdata is writable by container user (uid 1000) just in case
+          sudo chown -R 1000:1000 esdata
+        env:
+          GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
+
+      - name: Start Elasticsearch
+        run: docker-compose up -d elasticsearch
+
+      - name: Wait for Elasticsearch
+        run: |
+          timeout 60 bash -c 'until curl -s http://localhost:62223/_cat/health > /dev/null; do sleep 5; done'
+
+      - name: Install GCS Plugin & Keystore
+        run: |
+          docker-compose exec -T elasticsearch bin/elasticsearch-plugin install -b repository-gcs
+          docker-compose exec -T elasticsearch bin/elasticsearch-keystore add-file gcs.client.default.credentials_file data/gcs.json
+
+      - name: Restart Elasticsearch
+        run: docker-compose restart elasticsearch
+
+      - name: Wait for Elasticsearch again
+        run: |
+          timeout 60 bash -c 'until curl -s http://localhost:62223/_cat/health > /dev/null; do sleep 5; done'
+
+      - name: Register GCS Repository
+        run: |
+          curl -s -X PUT "http://localhost:62223/_snapshot/cofacts" -H 'Content-Type: application/json' -d '{
+            "type": "gcs",
+            "settings": {
+              "bucket": "rumors-db",
+              "readonly": true
+            }
+          }'
+
+      - name: Find Latest Snapshot
+        id: find-snapshot
+        run: |
+          SNAPSHOTS=$(curl -s "http://localhost:62223/_snapshot/cofacts/_all?verbose=true")
+          # Sort by start_time_in_millis and get the last one
+          LATEST_SNAPSHOT=$(echo "$SNAPSHOTS" | jq -r '.snapshots | sort_by(.start_time_in_millis) | last | .snapshot')
+          echo "Latest snapshot: $LATEST_SNAPSHOT"
+          echo "snapshot=$LATEST_SNAPSHOT" >> $GITHUB_OUTPUT
+
+      - name: Restore Snapshot
+        run: |
+          SNAPSHOT_NAME=${{ steps.find-snapshot.outputs.snapshot }}
+          if [ -z "$SNAPSHOT_NAME" ] || [ "$SNAPSHOT_NAME" == "null" ]; then
+            echo "Error: No snapshot found or failed to parse"
+            exit 1
+          fi
+          echo "Restoring $SNAPSHOT_NAME..."
+
+          # Delete all indices first
+          curl -s -X DELETE "http://localhost:62223/_all"
+
+          # Restore with wait_for_completion=true
+          curl -s -X POST "http://localhost:62223/_snapshot/cofacts/$SNAPSHOT_NAME/_restore?wait_for_completion=true" -H 'Content-Type: application/json' -d '{
+            "indices": "*,-urls*"
+          }'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate CSVs
+        run: npm start
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: opendata-csvs
+          path: data/*.zip


### PR DESCRIPTION
This PR adds a GitHub Actions workflow `.github/workflows/opendata.yml` that allows manual generation of Open Data CSV files.

The workflow performs the following steps:
1.  Sets up an Elasticsearch 6.3.2 container (matching `docker-compose.yml`).
2.  Installs the `repository-gcs` plugin and configures it with `GCS_CREDENTIALS` secret.
3.  Registers the GCS snapshot repository.
4.  Finds the latest snapshot and restores it.
5.  Runs `npm start` to generate CSV files.
6.  Uploads the generated CSV files as artifacts.

To use this workflow, you must add a `GCS_CREDENTIALS` secret to the repository containing the JSON key for the service account with access to the GCS bucket.

---
*PR created automatically by Jules for task [704352632902413376](https://jules.google.com/task/704352632902413376) started by @MrOrz*