### PR TITLE
Automate dataset generation and decouple Hugging Face sync

### DIFF
--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -149,10 +149,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: false
 
       - name: Upload to Hugging Face
         run: >-
-          uvx --from huggingface_hub huggingface-cli upload Cofacts/line-msg-fact-check-tw ./data .
+          uvx --from "huggingface_hub[cli]<0.25.0" huggingface-cli upload Cofacts/line-msg-fact-check-tw ./data .
           --repo-type dataset
           --commit-message "${{ needs.generate-opendata.outputs.snapshot }} update"
           --token ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -2,10 +2,14 @@ name: Generate Open Data
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
 
 jobs:
   generate-opendata:
     runs-on: ubuntu-latest
+    outputs:
+      snapshot: ${{ steps.find-snapshot.outputs.snapshot }}
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
@@ -114,3 +118,41 @@ jobs:
         with:
           name: opendata-csvs
           path: data/*.zip
+
+  update-readme:
+    needs: generate-opendata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update README.md
+        run: |
+          sed -i "s/<!-- SNAPSHOT_DATE -->.*<!-- \/SNAPSHOT_DATE -->/<!-- SNAPSHOT_DATE -->${{ needs.generate-opendata.outputs.snapshot }}<!-- \/SNAPSHOT_DATE -->/g" README.md
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet || git commit -am "chore: update latest snapshot date to ${{ needs.generate-opendata.outputs.snapshot }}"
+          git push
+
+  upload-dataset:
+    needs: generate-opendata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opendata-csvs
+          path: data
+
+      - name: Install Hugging Face Hub CLI
+        run: pip install -U "huggingface_hub[cli]"
+
+      - name: Upload to Hugging Face
+        run: >-
+          huggingface-cli upload Cofacts/line-msg-fact-check-tw ./data .
+          --repo-type dataset
+          --commit-message "${{ needs.generate-opendata.outputs.snapshot }} update"
+          --token ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload to Hugging Face
         run: >-
-          uvx --from "huggingface_hub[cli]<0.25.0" huggingface-cli upload Cofacts/line-msg-fact-check-tw ./data .
+          uvx --from huggingface_hub hf upload Cofacts/line-msg-fact-check-tw ./data .
           --repo-type dataset
           --commit-message "${{ needs.generate-opendata.outputs.snapshot }} update"
           --token ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -147,17 +147,12 @@ jobs:
           name: opendata-csvs
           path: data
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install Hugging Face Hub CLI
-        run: pip install "huggingface_hub[cli]<0.25.0"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Upload to Hugging Face
         run: >-
-          huggingface-cli upload Cofacts/line-msg-fact-check-tw ./data .
+          uvx --from huggingface_hub huggingface-cli upload Cofacts/line-msg-fact-check-tw ./data .
           --repo-type dataset
           --commit-message "${{ needs.generate-opendata.outputs.snapshot }} update"
           --token ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -147,6 +147,11 @@ jobs:
           name: opendata-csvs
           path: data
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install Hugging Face Hub CLI
         run: pip install -U "huggingface_hub[cli]"
 

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -153,7 +153,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Hugging Face Hub CLI
-        run: pip install -U "huggingface_hub[cli]"
+        run: pip install "huggingface_hub[cli]<0.25.0"
 
       - name: Upload to Hugging Face
         run: >-

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -3,7 +3,7 @@ name: Generate Open Data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '24 16 * * 0'
 
 jobs:
   generate-opendata:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 【Cofacts 真的假的】Open Datasets
 =====
 
-Latest dataset snapshot: <!-- SNAPSHOT_DATE -->2026-03-01<!-- /SNAPSHOT_DATE -->
+Latest dataset snapshot: <!-- SNAPSHOT_DATE -->2026-01-25<!-- /SNAPSHOT_DATE -->
 
 [![CI test](https://github.com/cofacts/opendata/actions/workflows/ci.yml/badge.svg)](https://github.com/cofacts/opendata/actions/workflows/ci.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 【Cofacts 真的假的】Open Datasets
 =====
 
-Latest dataset snapshot: <!-- SNAPSHOT_DATE -->2026-01-25<!-- /SNAPSHOT_DATE -->
+Latest dataset snapshot: <!-- SNAPSHOT_DATE -->2026-03-01<!-- /SNAPSHOT_DATE -->
 
 [![CI test](https://github.com/cofacts/opendata/actions/workflows/ci.yml/badge.svg)](https://github.com/cofacts/opendata/actions/workflows/ci.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 【Cofacts 真的假的】Open Datasets
 =====
 
+Latest dataset snapshot: <!-- SNAPSHOT_DATE -->2026-01-25<!-- /SNAPSHOT_DATE -->
+
 [![CI test](https://github.com/cofacts/opendata/actions/workflows/ci.yml/badge.svg)](https://github.com/cofacts/opendata/actions/workflows/ci.yml)
 
 We publish Cofacts data as Hugging Face dataset [`Cofacts/line-msg-fact-check-tw`](https://huggingface.co/datasets/Cofacts/line-msg-fact-check-tw). Application of Cofacts data has also been moved to Hugging Face.


### PR DESCRIPTION
Implements automated weekly dataset generation as per user request.

Modifies `.github/workflows/opendata.yml` to:
- Trigger on a weekly schedule (`0 0 * * 1`).
- Pass the snapshot date as an output from the primary data generation job.
- Use an independent job to automatically update `README.md` with the new snapshot date and commit the changes.
- Use another independent job to upload the generated dataset CSV files to Hugging Face via the huggingface-cli.

Updates `README.md` to establish the HTML comment block tracking the snapshot date.

---
*PR created automatically by Jules for task [12801888251781349117](https://jules.google.com/task/12801888251781349117) started by @MrOrz*