### PR TITLE
refactor: migrate from Elasticsearch 6.8 to 9.2 and Node 18 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rumors-test-db:
-        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
+        image: elasticsearch:9.2.2
         ports:
           - 62223:9200
         env:
           discovery.type: single-node
+          xpack.security.enabled: 'false'
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cat/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     steps:
 
       - name: Checkout rumors-db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rumors-test-db:
-        image: elasticsearch:9.2.2
+        image: elasticsearch:9.3.2
         ports:
           - 62223:9200
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rumors-test-db:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
         ports:
           - 62223:9200
+        env:
+          discovery.type: single-node
     steps:
 
       - name: Checkout rumors-db
@@ -23,7 +25,7 @@ jobs:
           repository: 'cofacts/rumors-db'
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Initialize DB indexes

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
 
-      - name: Install GCS Plugin & Keystore
+      - name: Configure GCS Keystore
         run: |
           # Find the container ID
           CONTAINER_ID=$(docker ps --filter "ancestor=elasticsearch:9.2.2" --format "{{.ID}}")
@@ -51,9 +51,6 @@ jobs:
             echo "Error: Elasticsearch container not found"
             exit 1
           fi
-
-          # Install plugin
-          docker exec $CONTAINER_ID bin/elasticsearch-plugin install -b repository-gcs
 
           # Add credentials to keystore
           # Copy credentials file into container
@@ -65,7 +62,7 @@ jobs:
           # Clean up credentials file inside container
           docker exec $CONTAINER_ID rm /usr/share/elasticsearch/config/gcs.json
 
-          # Restart container to load plugin
+          # Restart container to reload keystore
           docker restart $CONTAINER_ID
 
       - name: Wait for Elasticsearch
@@ -77,7 +74,8 @@ jobs:
           curl -s -X PUT "http://localhost:62223/_snapshot/cofacts" -H 'Content-Type: application/json' -d '{
             "type": "gcs",
             "settings": {
-              "bucket": "rumors-db",
+              "bucket": "cofacts-db-snapshots",
+              "base_path": "v9",
               "readonly": true
             }
           }'

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -12,7 +12,7 @@ jobs:
       snapshot: ${{ steps.find-snapshot.outputs.snapshot }}
     services:
       elasticsearch:
-        image: elasticsearch:9.2.2
+        image: elasticsearch:9.3.2
         ports:
           - 62223:9200
         env:
@@ -44,7 +44,7 @@ jobs:
       - name: Configure GCS Keystore
         run: |
           # Find the container ID
-          CONTAINER_ID=$(docker ps --filter "ancestor=elasticsearch:9.2.2" --format "{{.ID}}")
+          CONTAINER_ID=$(docker ps --filter "ancestor=elasticsearch:9.3.2" --format "{{.ID}}")
           echo "Elasticsearch container ID: $CONTAINER_ID"
 
           if [ -z "$CONTAINER_ID" ]; then

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -12,11 +12,12 @@ jobs:
       snapshot: ${{ steps.find-snapshot.outputs.snapshot }}
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
+        image: elasticsearch:9.2.2
         ports:
           - 62223:9200
         env:
           discovery.type: single-node
+          xpack.security.enabled: 'false'
         options: >-
           --health-cmd "curl http://localhost:9200/_cat/health"
           --health-interval 10s
@@ -43,7 +44,7 @@ jobs:
       - name: Install GCS Plugin & Keystore
         run: |
           # Find the container ID
-          CONTAINER_ID=$(docker ps --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:9.2.2" --format "{{.ID}}")
+          CONTAINER_ID=$(docker ps --filter "ancestor=elasticsearch:9.2.2" --format "{{.ID}}")
           echo "Elasticsearch container ID: $CONTAINER_ID"
 
           if [ -z "$CONTAINER_ID" ]; then

--- a/.github/workflows/opendata.yml
+++ b/.github/workflows/opendata.yml
@@ -12,7 +12,7 @@ jobs:
       snapshot: ${{ steps.find-snapshot.outputs.snapshot }}
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
         ports:
           - 62223:9200
         env:
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Prepare directory and secrets
@@ -43,7 +43,7 @@ jobs:
       - name: Install GCS Plugin & Keystore
         run: |
           # Find the container ID
-          CONTAINER_ID=$(docker ps --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2" --format "{{.ID}}")
+          CONTAINER_ID=$(docker ps --filter "ancestor=docker.elastic.co/elasticsearch/elasticsearch:9.2.2" --format "{{.ID}}")
           echo "Elasticsearch container ID: $CONTAINER_ID"
 
           if [ -z "$CONTAINER_ID" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,16 @@ version: '2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
     volumes:
       - "./esdata:/usr/share/elasticsearch/data"
     environment:
       - "path.repo=/usr/share/elasticsearch/data"
+      - "discovery.type=single-node"
     ports:
       - "62223:9200"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.3.2
+    image: docker.elastic.co/kibana/kibana:9.2.2
     ports:
       - "62224:5601"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,17 @@ version: '2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.2
+    image: elasticsearch:9.2.2
     volumes:
       - "./esdata:/usr/share/elasticsearch/data"
     environment:
       - "path.repo=/usr/share/elasticsearch/data"
       - "discovery.type=single-node"
+      - "xpack.security.enabled=false"
     ports:
       - "62223:9200"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:9.2.2
+    image: kibana:9.2.2
     ports:
       - "62224:5601"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ version: '2'
 
 services:
   elasticsearch:
-    image: elasticsearch:9.2.2
+    image: elasticsearch:9.3.2
     volumes:
       - "./esdata:/usr/share/elasticsearch/data"
     environment:
@@ -22,6 +22,6 @@ services:
       - "62223:9200"
 
   kibana:
-    image: kibana:9.2.2
+    image: kibana:9.3.2
     ports:
       - "62224:5601"

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -16,6 +16,17 @@ const client = new Client({
   node: ELASTICSEARCH_URL,
 });
 
+const ANALYTICS_SOURCE_INCLUDES = [
+  'type',
+  'docId',
+  'date',
+  'stats.lineUser',
+  'stats.lineVisit',
+  'stats.webUser',
+  'stats.webVisit',
+  'stats.liff',
+];
+
 /**
  * @param {string} input
  * @returns {string} - input's sha256 hash hex string. Empty string if input is falsy.
@@ -26,9 +37,46 @@ function sha256(input) {
     : '';
 }
 
+async function* mergeAsyncIterables(iterables) {
+  const entries = iterables.map((iterable) => {
+    const iterator = iterable[Symbol.asyncIterator]();
+    return {
+      iterator,
+      next: iterator.next().then((result) => ({ iterator, result })),
+    };
+  });
+
+  while (entries.length > 0) {
+    const { iterator, result } = await Promise.race(
+      entries.map((entry) => entry.next)
+    );
+    const entryIndex = entries.findIndex(
+      (entry) => entry.iterator === iterator
+    );
+
+    if (entryIndex === -1) continue;
+
+    if (result.done) {
+      entries.splice(entryIndex, 1);
+      continue;
+    }
+
+    entries[entryIndex].next = iterator
+      .next()
+      .then((nextResult) => ({ iterator, result: nextResult }));
+    yield result.value;
+  }
+}
+
 async function* scanIndex(
   index,
-  { size = 200, sourceIncludes = undefined, sort = undefined } = {}
+  {
+    size = 200,
+    sourceIncludes = undefined,
+    sort = undefined,
+    slice = undefined,
+    progressLabel = index,
+  } = {}
 ) {
   let processedCount = 0;
 
@@ -38,26 +86,51 @@ async function* scanIndex(
     scroll: '5m',
     _source_includes: sourceIncludes,
     sort,
+    slice,
   });
 
   let scrollId = result._scroll_id;
 
-  while (result.hits.hits.length > 0) {
-    for (const hit of result.hits.hits) {
-      processedCount += 1;
-      yield hit;
-    }
+  try {
+    while (result.hits.hits.length > 0) {
+      for (const hit of result.hits.hits) {
+        processedCount += 1;
+        yield hit;
+      }
 
-    if (processedCount % 10000 === 0) {
-      console.info(`${index}:\t${processedCount} processed`);
-    }
+      if (processedCount % 10000 === 0) {
+        console.info(`${progressLabel}:\t${processedCount} processed`);
+      }
 
-    result = await client.scroll({
-      scroll_id: scrollId,
-      scroll: '5m',
-    });
-    scrollId = result._scroll_id;
+      result = await client.scroll({
+        scroll_id: scrollId,
+        scroll: '5m',
+      });
+      scrollId = result._scroll_id;
+    }
+  } finally {
+    if (scrollId) {
+      try {
+        await client.clearScroll({
+          scroll_id: scrollId,
+        });
+      } catch (error) {
+        console.warn(`Failed to clear scroll for ${progressLabel}: ${error}`);
+      }
+    }
   }
+}
+
+function scanIndexInSlices(index, { slices, ...options }) {
+  return mergeAsyncIterables(
+    Array.from({ length: slices }, (_, sliceId) =>
+      scanIndex(index, {
+        ...options,
+        slice: { id: sliceId, max: slices },
+        progressLabel: `${index}[${sliceId + 1}/${slices}]`,
+      })
+    )
+  );
 }
 
 /**
@@ -461,18 +534,10 @@ pipeline(
 );
 
 pipeline(
-  scanIndex('analytics', {
+  scanIndexInSlices('analytics', {
+    slices: 8,
     size: 5000,
-    sourceIncludes: [
-      'type',
-      'docId',
-      'date',
-      'stats.lineUser',
-      'stats.lineVisit',
-      'stats.webUser',
-      'stats.webVisit',
-      'stats.liff',
-    ],
+    sourceIncludes: ANALYTICS_SOURCE_INCLUDES,
     sort: ['_doc'],
   }),
   dumpAnalytics,

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -29,34 +29,29 @@ function sha256(input) {
 async function* scanIndex(index) {
   let processedCount = 0;
 
-  let initialResult = await client.search({
+  let result = await client.search({
     index,
     size: 200,
     scroll: '5m',
-    track_total_hits: true,
   });
 
-  const totalCount = initialResult.hits.total.value;
-  let scrollId = initialResult._scroll_id;
+  let scrollId = result._scroll_id;
 
-  for (const hit of initialResult.hits.hits) {
-    processedCount += 1;
-    yield hit;
-  }
+  while (result.hits.hits.length > 0) {
+    for (const hit of result.hits.hits) {
+      processedCount += 1;
+      yield hit;
+    }
 
-  while (processedCount < totalCount) {
-    const scrollResult = await client.scroll({
+    if (processedCount % 10000 === 0) {
+      console.info(`${index}:\t${processedCount} processed`);
+    }
+
+    result = await client.scroll({
       scroll_id: scrollId,
       scroll: '5m',
     });
-    scrollId = scrollResult._scroll_id;
-    for (const hit of scrollResult.hits.hits) {
-      processedCount += 1;
-      yield hit;
-      if (processedCount % 100000 === 0) {
-        console.info(`${index}:\t${processedCount}/${totalCount}`);
-      }
-    }
+    scrollId = result._scroll_id;
   }
 }
 

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -29,13 +29,15 @@ function sha256(input) {
 async function* scanIndex(index) {
   let processedCount = 0;
 
-  const { body: initialResult } = await client.search({
+  let initialResult = await client.search({
     index,
     size: 200,
     scroll: '5m',
+    track_total_hits: true,
   });
 
-  const totalCount = initialResult.hits.total;
+  const totalCount = initialResult.hits.total.value;
+  let scrollId = initialResult._scroll_id;
 
   for (const hit of initialResult.hits.hits) {
     processedCount += 1;
@@ -43,10 +45,11 @@ async function* scanIndex(index) {
   }
 
   while (processedCount < totalCount) {
-    const { body: scrollResult } = await client.scroll({
-      scrollId: initialResult._scroll_id,
+    const scrollResult = await client.scroll({
+      scrollId,
       scroll: '5m',
     });
+    scrollId = scrollResult._scroll_id;
     for (const hit of scrollResult.hits.hits) {
       processedCount += 1;
       yield hit;

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -37,6 +37,30 @@ function sha256(input) {
     : '';
 }
 
+/**
+ * Normalize line breaks so bare carriage returns do not produce malformed CSV.
+ *
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function normalizeCsvValue(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+/**
+ * @param {unknown[][]} rows
+ * @returns {string}
+ */
+function csvStringifyRows(rows) {
+  return csvStringify(
+    rows.map((row) => row.map((value) => normalizeCsvValue(value)))
+  );
+}
+
 async function* mergeAsyncIterables(iterables) {
   const entries = iterables.map((iterable) => {
     const iterator = iterable[Symbol.asyncIterator]();
@@ -138,7 +162,7 @@ function scanIndexInSlices(index, { slices, ...options }) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpArticles(articles) {
-  yield csvStringify([
+  yield csvStringifyRows([
     [
       'id',
       'articleType',
@@ -154,7 +178,7 @@ async function* dumpArticles(articles) {
     ],
   ]);
   for await (const { _source, _id } of articles) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         _id,
         _source.articleType,
@@ -177,11 +201,11 @@ async function* dumpArticles(articles) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpArticleHyperlinks(articles) {
-  yield csvStringify([['articleId', 'url', 'normalizedUrl', 'title']]);
+  yield csvStringifyRows([['articleId', 'url', 'normalizedUrl', 'title']]);
 
   for await (const { _source, _id } of articles) {
     for (const hyperlink of _source.hyperlinks || []) {
-      yield csvStringify([
+      yield csvStringifyRows([
         [_id, hyperlink.url, hyperlink.normalizedUrl, hyperlink.title],
       ]);
     }
@@ -193,7 +217,7 @@ async function* dumpArticleHyperlinks(articles) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpArticleCategories(articles) {
-  yield csvStringify([
+  yield csvStringifyRows([
     [
       'articleId',
       'categoryId',
@@ -211,7 +235,7 @@ async function* dumpArticleCategories(articles) {
 
   for await (const { _source, _id } of articles) {
     for (const ac of _source.articleCategories || []) {
-      yield csvStringify([
+      yield csvStringifyRows([
         [
           _id,
           ac.categoryId,
@@ -235,7 +259,7 @@ async function* dumpArticleCategories(articles) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpArticleReplies(articles) {
-  yield csvStringify([
+  yield csvStringifyRows([
     [
       'articleId',
       'replyId',
@@ -252,7 +276,7 @@ async function* dumpArticleReplies(articles) {
 
   for await (const { _source, _id } of articles) {
     for (const ar of _source.articleReplies || []) {
-      yield csvStringify([
+      yield csvStringifyRows([
         [
           _id,
           ar.replyId,
@@ -275,12 +299,12 @@ async function* dumpArticleReplies(articles) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpReplies(replies) {
-  yield csvStringify([
+  yield csvStringifyRows([
     ['id', 'type', 'reference', 'userIdsha256', 'appId', 'text', 'createdAt'],
   ]);
 
   for await (const { _source, _id } of replies) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         _id,
         _source.type,
@@ -299,11 +323,11 @@ async function* dumpReplies(replies) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpReplyHyperlinks(replies) {
-  yield csvStringify([['replyId', 'url', 'normalizedUrl', 'title']]);
+  yield csvStringifyRows([['replyId', 'url', 'normalizedUrl', 'title']]);
 
   for await (const { _source, _id } of replies) {
     for (const hyperlink of _source.hyperlinks || []) {
-      yield csvStringify([
+      yield csvStringifyRows([
         [_id, hyperlink.url, hyperlink.normalizedUrl, hyperlink.title],
       ]);
     }
@@ -315,12 +339,12 @@ async function* dumpReplyHyperlinks(replies) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpCategories(categories) {
-  yield csvStringify([
+  yield csvStringifyRows([
     ['id', 'title', 'description', 'createdAt', 'updatedAt'],
   ]);
 
   for await (const { _id, _source } of categories) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         _id,
         _source.title,
@@ -337,7 +361,7 @@ async function* dumpCategories(categories) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpReplyRequests(replyRequests) {
-  yield csvStringify([
+  yield csvStringifyRows([
     [
       'articleId',
       'reason',
@@ -351,7 +375,7 @@ async function* dumpReplyRequests(replyRequests) {
   ]);
 
   for await (const { _source } of replyRequests) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         _source.articleId,
         _source.reason,
@@ -377,7 +401,7 @@ async function* dumpReplyRequests(replyRequests) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpArticleReplyFeedbacks(articleReplyFeedbacks) {
-  yield csvStringify([
+  yield csvStringifyRows([
     [
       'articleId',
       'replyId',
@@ -391,7 +415,7 @@ async function* dumpArticleReplyFeedbacks(articleReplyFeedbacks) {
   ]);
 
   for await (const { _source } of articleReplyFeedbacks) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         _source.articleId,
         _source.replyId,
@@ -411,7 +435,7 @@ async function* dumpArticleReplyFeedbacks(articleReplyFeedbacks) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpAnalytics(analytics) {
-  yield csvStringify([
+  yield csvStringifyRows([
     [
       'type',
       'docId',
@@ -426,7 +450,7 @@ async function* dumpAnalytics(analytics) {
   ]);
 
   for await (const { _source } of analytics) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         _source.type,
         _source.docId,
@@ -447,12 +471,12 @@ async function* dumpAnalytics(analytics) {
  * @returns {Promise<string>} Generated CSV string
  */
 async function* dumpUsers(users) {
-  yield csvStringify([
+  yield csvStringifyRows([
     ['userIdsha256', 'appId', 'createdAt', 'lastActiveAt', 'blockedReason'],
   ]);
 
   for await (const { _id, _source } of users) {
-    yield csvStringify([
+    yield csvStringifyRows([
       [
         sha256(_id),
         _source.appId,

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -26,13 +26,18 @@ function sha256(input) {
     : '';
 }
 
-async function* scanIndex(index) {
+async function* scanIndex(
+  index,
+  { size = 200, sourceIncludes = undefined, sort = undefined } = {}
+) {
   let processedCount = 0;
 
   let result = await client.search({
     index,
-    size: 200,
+    size,
     scroll: '5m',
+    _source_includes: sourceIncludes,
+    sort,
   });
 
   let scrollId = result._scroll_id;
@@ -455,5 +460,22 @@ pipeline(
   writeFile('article_reply_feedbacks.csv')
 );
 
-pipeline(scanIndex('analytics'), dumpAnalytics, writeFile('analytics.csv'));
+pipeline(
+  scanIndex('analytics', {
+    size: 5000,
+    sourceIncludes: [
+      'type',
+      'docId',
+      'date',
+      'stats.lineUser',
+      'stats.lineVisit',
+      'stats.webUser',
+      'stats.webVisit',
+      'stats.liff',
+    ],
+    sort: ['_doc'],
+  }),
+  dumpAnalytics,
+  writeFile('analytics.csv')
+);
 pipeline(scanIndex('users'), dumpUsers, writeFile('anonymized_users.csv'));

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 import crypto from 'crypto';
-import elasticsearch from '@elastic/elasticsearch';
+import { Client } from '@elastic/elasticsearch';
 
 // eslint-import-resolve does not support `exports` in package.json.
 // eslint-disable-next-line import/no-unresolved
@@ -12,7 +12,7 @@ import JSZip from 'jszip';
 const ELASTICSEARCH_URL = 'http://localhost:62223';
 const OUTPUT_DIR = './data';
 
-const client = new elasticsearch.Client({
+const client = new Client({
   node: ELASTICSEARCH_URL,
 });
 

--- a/dumpOpenData.js
+++ b/dumpOpenData.js
@@ -46,7 +46,7 @@ async function* scanIndex(index) {
 
   while (processedCount < totalCount) {
     const scrollResult = await client.scroll({
-      scrollId,
+      scroll_id: scrollId,
       scroll: '5m',
     });
     scrollId = scrollResult._scroll_id;

--- a/dumpUser.js
+++ b/dumpUser.js
@@ -39,23 +39,26 @@ function sha256(input) {
 async function scanIndex(index) {
   let result = [];
 
-  const { body: initialResult } = await client.search({
+  const initialResult = await client.search({
     index,
     size: 200,
     scroll: '5m',
+    track_total_hits: true,
   });
 
-  const totalCount = initialResult.hits.total;
+  const totalCount = initialResult.hits.total.value;
+  let scrollId = initialResult._scroll_id;
 
   initialResult.hits.hits.forEach((hit) => {
     result.push(hit);
   });
 
   while (result.length < totalCount) {
-    const { body: scrollResult } = await client.scroll({
-      scrollId: initialResult._scroll_id,
+    const scrollResult = await client.scroll({
+      scrollId,
       scroll: '5m',
     });
+    scrollId = scrollResult._scroll_id;
     scrollResult.hits.hits.forEach((hit) => {
       result.push(hit);
     });

--- a/dumpUser.js
+++ b/dumpUser.js
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import crypto from 'crypto';
-import elasticsearch from '@elastic/elasticsearch';
-import csvStringify from 'csv-stringify';
+import { Client } from '@elastic/elasticsearch';
+import { stringify as csvStringify } from 'csv-stringify';
 import JSZip from 'jszip';
 
 const ELASTICSEARCH_URL = 'http://localhost:62223';
 const OUTPUT_DIR = './data';
 
-const client = new elasticsearch.Client({
+const client = new Client({
   node: ELASTICSEARCH_URL,
 });
 
@@ -55,7 +55,7 @@ async function scanIndex(index) {
 
   while (result.length < totalCount) {
     const scrollResult = await client.scroll({
-      scrollId,
+      scroll_id: scrollId,
       scroll: '5m',
     });
     scrollId = scrollResult._scroll_id;

--- a/package-lock.json
+++ b/package-lock.json
@@ -301,10 +301,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -522,22 +523,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -676,10 +679,11 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1296,10 +1300,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1361,10 +1366,11 @@
       "license": "Apache-2.0"
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -1855,6 +1861,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2019,10 +2026,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2152,12 +2160,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -2177,10 +2186,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2463,10 +2473,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3045,6 +3056,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@elastic/elasticsearch": "^6.8.6",
+        "@elastic/elasticsearch": "^9.0.0",
         "csv-stringify": "^6.4.0",
         "jszip": "^3.1.5"
       },
@@ -21,7 +21,7 @@
         "prettier": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -34,20 +34,36 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-6.8.8.tgz",
-      "integrity": "sha512-51Jp3ZZ0oPqYPNlPG58XJ773MqJBx91rGNWCgVvy2UtxjxHsExAJooesOyLcoADnW0Dhyxu6yB8tziHnmyl8Vw==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-9.3.4.tgz",
+      "integrity": "sha512-Mp14fPEYx+WTfZdcvAaZ9WkLYGHQCbwMx6EP5VCucYdhv4cn/g2sbnMT5HzK+gX3XEpBnnkEK/+WysCKzxuo3A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.1.1",
-        "decompress-response": "^4.2.0",
-        "into-stream": "^5.1.0",
-        "ms": "^2.1.1",
-        "once": "^1.4.0",
-        "pump": "^3.0.0",
-        "secure-json-parse": "^2.1.0"
+        "@elastic/transport": "^9.3.5",
+        "apache-arrow": "18.x - 21.x",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-9.3.5.tgz",
+      "integrity": "sha512-hIMJbt1guqr3/N2zCN45k9hw9o78qcdsO0xietLe+Bfa+JL0YafHTgkWkM1oT3Ht5sGMJaDcJZiYomSMU6CtTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "1.x",
+        "@opentelemetry/core": "2.x",
+        "debug": "^4.4.1",
+        "hpagent": "^1.2.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^4.0.0",
+        "tslib": "^2.8.1",
+        "undici": "^7.19.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -174,6 +190,39 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
@@ -194,11 +243,41 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -250,7 +329,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -261,11 +339,40 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -477,7 +584,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -489,11 +595,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -504,8 +624,45 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -538,11 +695,12 @@
       "integrity": "sha512-HQsw0QXiN5fdlO+R8/JzCZnR3Fqp8E87YVnhHlaPtNGJjt6ffbV0LpOkieIb1x6V1+xt878IYq77SpXHWAqKkA=="
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -551,22 +709,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/deep-is": {
@@ -661,14 +803,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/es-abstract": {
@@ -1173,6 +1307,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1203,6 +1354,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
@@ -1216,15 +1373,6 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -1414,7 +1562,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1468,6 +1615,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/human-signals": {
@@ -1545,18 +1701,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/into-stream": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
-      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-array-buffer": {
@@ -1886,6 +2030,14 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1972,6 +2124,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2013,17 +2171,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2174,6 +2321,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2226,14 +2374,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/p-is-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -2374,15 +2514,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -2666,9 +2797,20 @@
       }
     },
     "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/set-function-name": {
       "version": "2.0.1",
@@ -2832,7 +2974,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2866,6 +3007,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/text-table": {
@@ -2911,10 +3065,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3005,6 +3159,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3019,6 +3182,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.2.tgz",
+      "integrity": "sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/untildify": {
       "version": "4.0.0",
@@ -3093,10 +3271,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/cofacts/opendata#readme",
   "dependencies": {
     "csv-stringify": "^6.4.0",
-    "@elastic/elasticsearch": "^6.8.6",
+    "@elastic/elasticsearch": "^9.0.0",
     "jszip": "^3.1.5"
   },
   "devDependencies": {
@@ -39,6 +39,6 @@
     "prettier": "^3.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
This PR migrates the cofacts-opendata project from Elasticsearch 6.8 to 9.2 and Node.js 18 to 24. It includes necessary code refactors for the @elastic/elasticsearch v9 client, such as removing the `body` wrapper from responses and updating how total hits are accessed. Additionally, it ensures accurate data exports by enabling `track_total_hits` and improves the scroll logic by updating the `scrollId` in each iteration. Infrastructure and CI/CD workflows have also been updated to match the new stack.

Fixes #31

---
*PR created automatically by Jules for task [9232966085038031085](https://jules.google.com/task/9232966085038031085) started by @MrOrz*